### PR TITLE
[#14] Fix project to ticket relation

### DIFF
--- a/src/jira/tickets.rs
+++ b/src/jira/tickets.rs
@@ -228,7 +228,12 @@ impl JiraTickets {
         jira_auth: &JiraClient,
         project_key: &str,
     ) -> Result<Vec<TicketData>, SurrealDbError> {
-        let tickets: Vec<TicketData> = db.select("tickets").await?;
+        let sql = r#"
+            SELECT * FROM tickets WHERE fields.project.key = $project_key
+            "#;
+        let mut query = db.query(sql).bind(("project_key", format!("{}", project_key))).await?;
+        info!("query data from get_jira_tickets -- {:?}", query);
+        let tickets: Vec<TicketData> = query.take(0)?;
         if tickets.is_empty() {
             return Ok(Self::save_jira_tickets(db, jira_auth, project_key).await?);
         }

--- a/src/widgets/projects.rs
+++ b/src/widgets/projects.rs
@@ -1,3 +1,4 @@
+use log::info;
 use tui::{
     backend::Backend,
     layout::Rect,
@@ -43,6 +44,8 @@ impl ProjectsWidget {
             None => None,
         };
 
+        info!("selecting project next -- {:?}", i);
+
         self.state.select(i);
     }
 
@@ -57,6 +60,8 @@ impl ProjectsWidget {
             }
             None => None,
         };
+
+        info!("selecting project previous -- {:?}", i);
 
         self.state.select(i);
     }
@@ -77,7 +82,10 @@ impl ProjectsWidget {
 
     pub fn selected_project(&self) -> Option<&Project> {
         match self.state.selected() {
-            Some(i) => self.projects.get(i),
+            Some(i) => {
+                info!("selected project -- {:?}", i);
+                self.projects.get(i)
+            },
             None => None,
         }
     }

--- a/src/widgets/tickets.rs
+++ b/src/widgets/tickets.rs
@@ -1,3 +1,4 @@
+use log::info;
 use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
 use tui::{


### PR DESCRIPTION
fix: #14
- Fixes project to ticket relation.  Previously when going back and fourth between projects, it would load the incorrect tickets.  This was due to the database returning incorrect results.  Now we are querying the specific projects from the in-memory database