### PR TITLE
36: Refactor get tickets

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -200,27 +200,21 @@ impl App {
 
     pub async fn next_ticket_page(&mut self) -> anyhow::Result<()> {
         let project = self.projects.selected_project().unwrap();
-        self.jira
-            .get_jira_tickets(project.key.clone(), true, false)
-            .await?;
+        self.jira.get_next_ticket_page(&project.key).await?;
         self.tickets.update(&self.jira.tickets.issues).await?;
         Ok(())
     }
 
     pub async fn previous_ticket_page(&mut self) -> anyhow::Result<()> {
         let project = self.projects.selected_project().unwrap();
-        self.jira
-            .get_jira_tickets(project.key.clone(), false, true)
-            .await?;
+        self.jira.get_previous_tickets_page(&project.key).await?;
         self.tickets.update(&self.jira.tickets.issues).await?;
         Ok(())
     }
 
     pub async fn get_first_ticket_set(&mut self) -> anyhow::Result<()> {
         let project = self.projects.selected_project().unwrap();
-        self.jira
-            .get_jira_tickets(project.key.clone(), false, true)
-            .await?;
+        self.jira.get_jira_tickets(&project.key).await?;
         self.tickets.update(&self.jira.tickets.issues).await?;
         Ok(())
     }

--- a/src/jira/projects.rs
+++ b/src/jira/projects.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Project {
     pub key: String,
-    pub tickets: Option<Vec<TicketData>>
+    pub tickets: Option<Vec<TicketData>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/widgets/projects.rs
+++ b/src/widgets/projects.rs
@@ -96,7 +96,7 @@ impl ProjectsWidget {
         &mut self,
         f: &mut Frame<B>,
         focused: bool,
-        rect: Rect,
+        _rect: Rect,
         // _focused: bool,
     ) -> anyhow::Result<()> {
         let title = "Projects";

--- a/src/widgets/tickets.rs
+++ b/src/widgets/tickets.rs
@@ -1,6 +1,3 @@
-use log::info;
-use surrealdb::engine::any::Any;
-use surrealdb::Surreal;
 use tui::{
     backend::Backend,
     layout::{Constraint, Rect},
@@ -8,18 +5,9 @@ use tui::{
     Frame,
 };
 
-use crate::{
-    config::KeyConfig,
-    event::key::Key,
-    jira::{
-        auth::JiraClient,
-        tickets::{JiraTickets, TicketData},
-    },
-};
+use crate::{config::KeyConfig, event::key::Key, jira::tickets::TicketData};
 
 use super::{commands::CommandInfo, draw_block_style, draw_highlight_style, Component, EventState};
-
-type SurrealAny = Surreal<Any>;
 
 #[derive(Debug)]
 pub struct TicketWidget {


### PR DESCRIPTION
When grabbing tickets from JIRA API and recording it to the database, it's best if we have one method to do this rather than repeating it on several other methods

fix: #36