### PR TITLE
Reset terminal on crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +64,9 @@ name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "approx"
@@ -184,6 +202,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -1057,6 +1090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1794,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2319,6 +2376,12 @@ dependencies = [
  "num-traits",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ surrealdb = { version = "1.0.0-beta.9", features = ["kv-mem"] }
 log = "0.4.17"
 fern = "0.6.1"
 chrono = "0.4.23"
-anyhow = "1.0.68"
+anyhow = { version = "1.0.68", features = ["backtrace"] }
 async-trait = "0.1.64"
 structopt = "0.3.26"
 env_logger = "0.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,8 @@ async fn main() -> anyhow::Result<()> {
     loop {
         terminal.draw(|f| {
             if let Err(err) = app.draw(f) {
-                // outln!(config #Error, "error: {}", err.to_string());
+                shutdown_terminal();
+                eprintln!("Error: {err:?}");
                 std::process::exit(1);
             }
         })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use crate::event::event::Event;
 use anyhow;
 use app::App;
 use crossterm::{
+    cursor,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
@@ -81,7 +82,6 @@ async fn main() -> anyhow::Result<()> {
     }
 
     shutdown_terminal();
-    terminal.show_cursor()?;
 
     Ok(())
 }
@@ -103,5 +103,11 @@ fn shutdown_terminal() {
 
     if let Err(e) = leave_raw_mode {
         eprintln!("leave_raw_mode failed:\n{}", e);
+    }
+
+    let show_cursor = io::stdout().execute(cursor::Show).map(|_| ());
+
+    if let Err(e) = show_cursor {
+        eprintln!("show_cursor failed:\n{}", e);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,13 @@ async fn main() -> anyhow::Result<()> {
 
     setup_terminal()?;
 
+    // setup panic handler to restore terminal before exiting
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic| {
+        shutdown_terminal();
+        original_hook(panic);
+    }));
+
     let mut app: App = App::new(config.clone()).await?;
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);


### PR DESCRIPTION
So this tries to make sure to leave the terminal in a valid state when the app crashes.

I also took the opportunity to enable the `anyhow` `backtrace` feature, super useful in my experience.