### PR TITLE
86: Keep entire ticket list when using search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jirust"
-version = "0.1.0-alpha.18"
+version = "0.1.0-alpha.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/moali87/jirust"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/moali87/jirust"
-version = "0.1.0-alpha.18"
+version = "0.1.0-alpha.19"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An application with developers and engineers in mind.  It is solely focused on u
 ## Install
 make sure you have Rust installed.  See https://www.rust-lang.org/tools/install
 
-Run `cargo install jirust --version 0.1.0-alpha.18`
+Run `cargo install jirust --version 0.1.0-alpha.19`
 
 ## Important notices
 * This is currently tested with JIRA cloud.
@@ -17,9 +17,7 @@ Run `cargo install jirust --version 0.1.0-alpha.18`
 
 These are environment variables required to use this tool.
 
-* JIRA_USER_EMAIL: "example@examplerserver.com" 
 * JIRA_API_KEY: "abcdefghijklmnopqrstuvwxyz1234567890"
-* JIRA_DOMAIN: "https://mycompany.atlassian.net"
 
 You will also need a config file in `$HOME/.config/jirust/config.toml`.  Please look at the sample.toml for its contents.
 
@@ -49,8 +47,8 @@ You will also need a config file in `$HOME/.config/jirust/config.toml`.  Please 
 - [X] UI to view selected issue details
 - [ ] POC support for JIRA data types such as tables, list, and code blocks using atlassian document format
 - [ ] Add functionality to support ticket sorting by sprint
-- [ ] Only view specified ticket status
-- [ ] Only view tickets assigned to specific user
+- [X] Only view specified ticket status
+- [X] Only view tickets assigned to specific user
 
 ## Credit
 I've been copying a lot of [gobang](https://github.com/TaKO8Ki/gobang/tree/main) project.  This wouldn't have been possible if it wasn't for that project.  Thank you.

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,6 @@ use crate::{
     widgets::{Component, EventState},
 };
 use crate::{jira::Jira, widgets::projects::ProjectsWidget};
-use log::info;
 use tui::layout::Rect;
 use tui::{
     backend::Backend,
@@ -339,28 +338,28 @@ impl App {
     pub async fn next_ticket_page(&mut self) -> anyhow::Result<()> {
         let project = self.projects.selected().unwrap();
         self.jira.get_next_ticket_page(&project.key).await?;
-        self.tickets.update(self.jira.tickets.issues.clone()).await?;
+        self.tickets.update(self.jira.tickets.issues.clone(), true).await?;
         Ok(())
     }
 
     pub async fn previous_ticket_page(&mut self) -> anyhow::Result<()> {
         let project = self.projects.selected().unwrap();
         self.jira.get_previous_tickets_page(&project.key).await?;
-        self.tickets.update(self.jira.tickets.issues.clone()).await?;
+        self.tickets.update(self.jira.tickets.issues.clone(), true).await?;
         Ok(())
     }
 
     pub async fn update_all_tickets(&mut self) -> anyhow::Result<()> {
         let project = self.projects.selected().unwrap();
         self.jira.get_jira_tickets(&project.key).await?;
-        self.tickets.update(self.jira.tickets.issues.clone()).await?;
+        self.tickets.update(self.jira.tickets.issues.clone(), true).await?;
         Ok(())
     }
 
     pub async fn update_single_ticket(&mut self, ticket_key: &str) -> anyhow::Result<()> {
         let ticket = self.jira.search_cache_ticket(ticket_key).await?;
-        info!("app4 -- update single ticket {:?}", ticket);
-        self.tickets.update(vec![ticket]).await
+        self.tickets.update(vec![ticket], false).await?;
+        self.tickets.select_ticket(ticket_key)
     }
 
     pub async fn update_search_tickets(&mut self) -> anyhow::Result<()> {

--- a/src/widgets/tickets.rs
+++ b/src/widgets/tickets.rs
@@ -177,9 +177,11 @@ impl TicketWidget {
         Ok(())
     }
 
-    pub async fn update(&mut self, tickets: Vec<TicketData>) -> anyhow::Result<()> {
-        self.tickets.clear();
-        self.tickets = tickets;
+    pub async fn update(&mut self, mut tickets: Vec<TicketData>, clear: bool) -> anyhow::Result<()> {
+        if clear {
+            self.tickets.clear();
+        }
+        self.tickets.append(&mut tickets);
         Ok(())
     }
 }


### PR DESCRIPTION
Currently search will clear out the remaining tickets and return the only ticket searched.  This will keep the existing tickets in view and select the searched ticket regardless if it needs to pull from the API or not.

fix: #86