### PR TITLE
key mappings proof-of-concept

### DIFF
--- a/src/widgets/help.rs
+++ b/src/widgets/help.rs
@@ -77,9 +77,9 @@ impl Component for HelpWidget {
                 return Ok(EventState::Consumed);
             }
             return Ok(EventState::NotConsumed);
-        } else if key == self.key_config.open_help {
-            self.show()?;
-            return Ok(EventState::Consumed);
+        // } else if key == self.key_config.open_help {
+        //     self.show()?;
+        //     return Ok(EventState::Consumed);
         }
         Ok(EventState::NotConsumed)
     }

--- a/src/widgets/tickets.rs
+++ b/src/widgets/tickets.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use tui::{
     backend::Backend,
     layout::{Constraint, Rect},
@@ -7,7 +9,7 @@ use tui::{
 
 use crate::{config::KeyConfig, event::key::Key, jira::tickets::TicketData};
 
-use super::{commands::CommandInfo, draw_block_style, draw_highlight_style, Component, EventState};
+use super::{commands::CommandInfo, draw_block_style, draw_highlight_style, Component, EventState, projects::Action};
 
 #[derive(Debug)]
 pub struct TicketWidget {
@@ -15,6 +17,7 @@ pub struct TicketWidget {
     key_config: KeyConfig,
     state: TableState,
     pub tickets: Vec<TicketData>,
+    pub key_mappings: HashMap<Key, Action>,
 }
 
 impl TicketWidget {
@@ -95,11 +98,26 @@ impl TicketWidget {
         labels_state.select(Some(0));
         state.select(Some(0));
 
+        let key_mappings = {
+            let mut map = HashMap::new();
+            map.insert(Key::Down, Action::ScrollDown(1));
+            map.insert(Key::Up, Action::ScrollUp(1));
+
+            map.insert(key_config.scroll_down, Action::ScrollDown(1));
+            map.insert(key_config.scroll_up, Action::ScrollUp(1));
+            map.insert(key_config.scroll_down_multiple_lines, Action::ScrollDown(10));
+            map.insert(key_config.scroll_up_multiple_lines, Action::ScrollUp(10));
+            map.insert(key_config.scroll_to_bottom, Action::ScrollToBottom);
+            map.insert(key_config.scroll_to_top, Action::ScrollToTop);
+            map
+        };
+
         Self {
             jira_domain,
             key_config,
             tickets: vec![],
             state,
+            key_mappings,
         }
     }
 

--- a/src/widgets/tickets.rs
+++ b/src/widgets/tickets.rs
@@ -9,12 +9,37 @@ use tui::{
 
 use crate::{config::KeyConfig, event::key::Key, jira::tickets::TicketData};
 
-use super::{commands::CommandInfo, draw_block_style, draw_highlight_style, Component, EventState, projects::Action};
+use super::{commands::{CommandInfo, CommandText}, draw_block_style, draw_highlight_style, Component, EventState};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Action {
+    OpenBrowser,
+    ScrollDown(usize),
+    ScrollUp(usize),
+    ScrollToBottom,
+    ScrollToTop,
+}
+
+impl Action {
+    pub fn to_command_text(self, key: Key) -> CommandText {
+        const CMD_GROUP_GENERAL: &str = "-- General --";
+        match self {
+            Self::OpenBrowser => CommandText::new(format!("Open Ticket in browser [{key}]"), CMD_GROUP_GENERAL),
+            Self::ScrollDown(line) =>
+                CommandText::new(format!("Scroll down {line} [{key}]"), CMD_GROUP_GENERAL),
+            Self::ScrollUp(line) =>
+                CommandText::new(format!("Scroll up {line} [{key}]"), CMD_GROUP_GENERAL),
+            Self::ScrollToBottom =>
+                CommandText::new(format!("Scroll to bottom [{key}]"), CMD_GROUP_GENERAL),
+            Self::ScrollToTop =>
+                CommandText::new(format!("Scroll to top [{key}]"), CMD_GROUP_GENERAL),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct TicketWidget {
     jira_domain: String,
-    key_config: KeyConfig,
     state: TableState,
     pub tickets: Vec<TicketData>,
     pub key_mappings: HashMap<Key, Action>,
@@ -103,6 +128,7 @@ impl TicketWidget {
             map.insert(Key::Down, Action::ScrollDown(1));
             map.insert(Key::Up, Action::ScrollUp(1));
 
+            map.insert(key_config.open_browser, Action::OpenBrowser);
             map.insert(key_config.scroll_down, Action::ScrollDown(1));
             map.insert(key_config.scroll_up, Action::ScrollUp(1));
             map.insert(key_config.scroll_down_multiple_lines, Action::ScrollDown(10));
@@ -114,7 +140,6 @@ impl TicketWidget {
 
         Self {
             jira_domain,
-            key_config,
             tickets: vec![],
             state,
             key_mappings,
@@ -222,28 +247,18 @@ impl Component for TicketWidget {
     fn commands(&self, _out: &mut Vec<CommandInfo>) {}
 
     fn event(&mut self, key: Key) -> anyhow::Result<EventState> {
-        if key == self.key_config.scroll_down {
-            self.next(1);
-            return Ok(EventState::Consumed);
-        } else if key == self.key_config.scroll_up {
-            self.previous(1);
-            return Ok(EventState::Consumed);
-        } else if key == self.key_config.scroll_down_multiple_lines {
-            self.next(10);
-            return Ok(EventState::Consumed);
-        } else if key == self.key_config.scroll_up_multiple_lines {
-            self.previous(10);
-            return Ok(EventState::Consumed);
-        } else if key == self.key_config.scroll_to_bottom {
-            self.go_to_bottom();
-            return Ok(EventState::Consumed);
-        } else if key == self.key_config.scroll_to_top {
-            self.go_to_top();
-            return Ok(EventState::Consumed);
-        } else if key == self.key_config.open_browser {
-            self.open_browser();
-            return Ok(EventState::Consumed);
+        if let Some(action) = self.key_mappings.get(&key) {
+            use Action::*;
+            match *action {
+                OpenBrowser => self.open_browser(),
+                ScrollDown(line) => self.next(line),
+                ScrollUp(line) => self.previous(line),
+                ScrollToBottom => self.go_to_bottom(),
+                ScrollToTop => self.go_to_top(),
+            }
+            Ok(EventState::Consumed)
+        } else {
+            Ok(EventState::NotConsumed)
         }
-        Ok(EventState::NotConsumed)
     }
 }


### PR DESCRIPTION
So I found some time to make a bit of a proof-of-concept for what I was thinking to ensure that that help menu stays synchronized with the actual key mappings.

Simply put, there are maps from Key -> Action, multiple to act at different levels.
Then both reacting on key press events as well generating the help menu contents uses these maps. ie. the maps are the source of truth for key mappings.

Pros:
- help menu is less likely to go out of sync
- we can easily support multiple keys for a single action
  - the PR has an example where the project menu can be scrolled with both j/k and up/down
- this is great first step to supporting custom key mappings, just change how the map is built!

Cons:
- the help menu is in arbitrary order
  - easy fix if we use [indexmap](https://github.com/bluss/indexmap) or similar
- we lose the ability to have combined help menu items (eg: "scroll [j/k/h/l]") 
  - again fixable by making how the help is generated more sophisticated, though I'll argue this isn't really worth it

Note: implementation is still rather rough, I had to break all other help menus in the process to get this working with minimal changes.