### PR TITLE
Update projects instead of create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jirust"
-version = "0.1.0-alpha.28"
+version = "0.1.0-alpha.29"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jirust"
-version = "0.1.0-alpha.27"
+version = "0.1.0-alpha.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/moali87/jirust"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/moali87/jirust"
-version = "0.1.0-alpha.28"
+version = "0.1.0-alpha.29"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/moali87/jirust"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/moali87/jirust"
-version = "0.1.0-alpha.27"
+version = "0.1.0-alpha.28"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An application with developers and engineers in mind.  It is solely focused on u
 ## Install
 make sure you have Rust installed.  See https://www.rust-lang.org/tools/install
 
-Run `cargo install jirust --version 0.1.0-alpha.26`
+Run `cargo install jirust --version 0.1.0-alpha.28`
 
 ## Important notices
 * This is currently tested with JIRA cloud.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ An application with developers and engineers in mind.  It is solely focused on u
 ## Install
 make sure you have Rust installed.  See https://www.rust-lang.org/tools/install
 
-Run `cargo install jirust --version 0.1.0-alpha.28`
+Run `cargo install jirust --version 0.1.0-alpha.29`
 
 ## Important notices
 * This is currently tested with JIRA cloud.
-* I'm (Author: Mo Ali) am an infrastructure engineer by trade.  This is my first programming project that I'm sharing out.  This is also my first rust project and am using it to learn rust.  You can watch my development on [twitch](https://www.twitch.tv/mo_ali141)
+* I (Author: Mo Ali) am an infrastructure engineer by trade.  This is my first programming project that I'm sharing out.  This is also my first rust project and am using it to learn rust.  You can watch my development on [twitch](https://www.twitch.tv/mo_ali141)
 
 ## Current requirements
 

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -357,7 +357,7 @@ impl Jira {
             .await?;
         let update_project_record: Project = self
             .db
-            .create(("projects", project_key))
+            .update(("projects", project_key))
             .content(project)
             .await?;
 


### PR DESCRIPTION
There seems to be some sort of issue regarding the cache.  Even if the cache already contains projects, it doesn't seem to use that existing table, instead it wants to create a new table.  Even though we are checking if projects is not an empty return before creating the table.

We need to add debug messages throughout the application to find out potentially where issues are.