### PR TITLE
improve error if first API call fails

### DIFF
--- a/src/jira/projects.rs
+++ b/src/jira/projects.rs
@@ -40,7 +40,7 @@ impl JiraProjects {
             .default_headers(headers)
             .https_only(true)
             .build()?;
-        client.get(url).send().await?.text().await
+        client.get(url).send().await?.error_for_status()?.text().await
     }
 
     pub async fn get_projects_next_page(

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,11 @@ async fn main() -> anyhow::Result<()> {
 
     let config = config::Config::new().unwrap();
 
-    setup_terminal()?;
+    let mut app: App = App::new(config.clone()).await?;
+    let stdout = io::stdout();
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    let events = event::event::Events::new(250);
 
     // setup panic handler to restore terminal before exiting
     let original_hook = std::panic::take_hook();
@@ -32,13 +36,7 @@ async fn main() -> anyhow::Result<()> {
         shutdown_terminal();
         original_hook(panic);
     }));
-
-    let mut app: App = App::new(config.clone()).await?;
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-    let events = event::event::Events::new(250);
-
+    setup_terminal()?;
     terminal.clear()?;
 
     loop {


### PR DESCRIPTION
fetching projects is the first thing that happens

don't set up the terminal until that succeeds
and report the error instead of "projects deserialized"