### PR TITLE
Bump cargo to match crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jirust"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/moali87/jirust"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/moali87/jirust"
-version = "1.1.4"
+version = "1.1.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Crates is out of sync due to faulty patch being release.  This should be a #patch