### PR TITLE
Build for multiple targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish
 on:
   push:
     tags:
-      - '*'
+      - "*"
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.AUTO_ACTION }}
@@ -57,6 +57,9 @@ jobs:
 
       - name: cargo login
         run: cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: cargo build
+        run: cargo build --release --all-targets
 
       - name: cargo publish
         run: cargo publish --config 'package.version="$(git describe --tags --abbrev=0)"'

--- a/.github/workflows/tag-bump.yml
+++ b/.github/workflows/tag-bump.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.64.0 # Don't use @master or @v1 unless you're happy to test the latest version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,18 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-bump"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3a224e28980ec7d69cb2f75ebbf2a9a05fda945575b217563a81cc5bfd1067"
-dependencies = [
- "cargo_metadata 0.7.4",
- "clap 2.34.0",
- "semver 0.9.0",
- "toml_edit 0.1.5",
-]
-
-[[package]]
 name = "cargo-platform"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +579,7 @@ checksum = "94912a89087caa43c6e335c054a00cb1d4d91b7a9f8b1ceea124b2bf6318c404"
 dependencies = [
  "anyhow",
  "bstr",
- "cargo_metadata 0.17.0",
+ "cargo_metadata",
  "clap 4.4.7",
  "clap-cargo",
  "concolor-control",
@@ -617,7 +599,7 @@ dependencies = [
  "once_cell",
  "quick-error",
  "regex",
- "semver 1.0.18",
+ "semver",
  "serde",
  "termcolor",
  "time 0.3.28",
@@ -628,26 +610,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "178d62b240c34223f265a4c1e275e37d62da163d421fc8d7f7e3ee340f803c57"
-dependencies = [
- "error-chain",
- "semver 0.9.0",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.18",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -838,7 +807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383f21342a464d4af96e9a4cad22a0b4f2880d4a5b3bbf5c9654dd1d9a224ee4"
 dependencies = [
  "anstyle",
- "cargo_metadata 0.17.0",
+ "cargo_metadata",
  "clap 4.4.7",
 ]
 
@@ -909,19 +878,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "combine"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
-dependencies = [
- "ascii",
- "byteorder",
- "either",
- "memchr",
- "unreachable",
-]
 
 [[package]]
 name = "combine"
@@ -1017,7 +973,7 @@ dependencies = [
  "memchr",
  "rayon",
  "rustc-hash",
- "semver 1.0.18",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1440,16 +1396,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
 ]
 
 [[package]]
@@ -2326,12 +2272,11 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jirust"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.2",
- "cargo-bump",
  "cargo-release",
  "chrono",
  "crossterm 0.25.0",
@@ -2369,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
 dependencies = [
  "cesu8",
- "combine 4.6.6",
+ "combine",
  "jni-sys",
  "log",
  "thiserror",
@@ -2518,12 +2463,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3867,7 +3806,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver",
 ]
 
 [[package]]
@@ -4084,28 +4023,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "send_wrapper"
@@ -4613,7 +4536,7 @@ dependencies = [
  "rust_decimal",
  "rustls 0.20.8",
  "scrypt",
- "semver 1.0.18",
+ "semver",
  "serde",
  "serde_json",
  "sha-1",
@@ -4984,17 +4907,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f53b1aca7d5fe2e17498a38cac0e1f5a33234d5b980fb36b9402bb93b98ae4"
-dependencies = [
- "chrono",
- "combine 3.8.1",
- "linked-hash-map",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
@@ -5217,15 +5129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5295,12 +5198,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/moali87/jirust"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/moali87/jirust"
-version = "1.1.5"
+version = "1.1.6"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -47,5 +47,12 @@ toml = "0.7.3"
 rustls-webpki = ">=0.101.4"
 time = ">=0.2.23"
 tungstenite = ">=0.20.1"
-cargo-bump = "1.1.0"
 cargo-release = "0.24.12"
+
+[build]
+targets = [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc"
+]

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,7 +158,11 @@ impl Default for JiraConfigFile {
         };
 
         let db_file = data.db_file;
-        let domain = data.domain;
+        let mut domain = data.domain.clone();
+        if !domain.starts_with("https://") {
+            domain = format!("https://{}", data.domain.clone())
+        }
+
         let jira_user_email = data.user_email;
 
         let jira_api_key = match env::var("JIRA_API_KEY") {


### PR DESCRIPTION
This #patch should build for all targets.  It also fixes domain naming convention.

fix: #140
fix: #141